### PR TITLE
#10 substitute event bus

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "baseUrl": ".",
+        "paths": {
+            "@/*": [
+                "./src/*"
+            ]
+        }
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ],
+    "include": [
+        "src/**/*"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "parser": "babel-eslint"
     },
     "rules": {
-      "no-console": 1,
+      "no-console": 0,
       "no-debugger": 1
     },
     "overrides": [

--- a/src/components/Confirmation.vue
+++ b/src/components/Confirmation.vue
@@ -17,23 +17,20 @@
 </template>
 
 <script>
-import { bus } from "@/plugins/bus.js";
+import { confirmation } from "../store.js";
 
 export default {
   name: "Confirmation",
-  data() {
-    return {
-      dialog: false,
-    };
-  },
-  methods: {
-    runConfirmation(confirmation) {
-      this.dialog = false;
-      bus.$emit('runConfirmation', confirmation);
+  computed: {
+    dialog() {
+      return confirmation.dialog;
     }
   },
-  created() {
-    bus.$on("toggle", (data) => (this.dialog = data));
+  methods: {
+    runConfirmation(enable) {
+      confirmation.dialog = enable;
+      confirmation.confirm = enable;
+    }
   },
 };
 </script>

--- a/src/plugins/bus.js
+++ b/src/plugins/bus.js
@@ -1,3 +1,0 @@
-import Vue from 'vue';
-
-export const bus = new Vue();

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -16,7 +16,7 @@ const routes = [
         component: () =>
           import(/* webpackChunkName: "about" */ "../views/ListaCaixas.vue"),
         meta: {
-          requiresAuth: true
+          requiresAuth: false
         }
       },
       {
@@ -25,7 +25,7 @@ const routes = [
         component: () =>
           import(/* webpackChunkName: "about" */ "../views/Caixa.vue"),
         meta: {
-          requiresAuth: true
+          requiresAuth: false
         }
       },
       {
@@ -34,7 +34,7 @@ const routes = [
         component: () =>
           import(/* webpackChunkName: "about" */ "../views/CaixaAberto.vue"),
         meta: {
-          requiresAuth: true
+          requiresAuth: false
         }
       },
       {
@@ -52,7 +52,7 @@ const routes = [
         component: () =>
           import(/* webpackChunkName: "about" */ "../views/Equipe.vue"),
         meta: {
-          requiresAuth: true
+          requiresAuth: false
         }
       },
     ]

--- a/src/store.js
+++ b/src/store.js
@@ -4,3 +4,12 @@ export const confirmation = Vue.observable({
     dialog: false,
     confirm: false
 });
+
+export const dialogConclude = () => {
+    confirmation.dialog = false;
+    confirmation.confirm = false;
+};
+
+export const openDialog = () => {
+    confirmation.dialog = true;
+};

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+
+export const confirmation = Vue.observable({
+    dialog: false,
+    confirm: false
+});

--- a/src/views/Caixa.vue
+++ b/src/views/Caixa.vue
@@ -45,13 +45,18 @@
 
 <script>
 import Confirmation from "@/components/Confirmation";
-import { bus } from "@/plugins/bus.js";
+import { confirmation } from '../store.js';
 import { storeCaixa, storeControleCaixa, turnNumber } from "@/services/caixa";
 import { VMoney } from "v-money";
 
 export default {
   name: "Caixa",
   components: { Confirmation },
+  computed: {
+    dialog() {
+      return confirmation.confirm;
+    }
+  },
   data() {
     return {
       valorInicial: "",
@@ -70,7 +75,7 @@ export default {
   },
 
   watch: {
-    confirmation(value) {
+    dialog(value) {
       if (value === true) {
         this.abrirCaixa();
       }
@@ -82,6 +87,12 @@ export default {
   methods: {
     abrirCaixa() {
       console.log(this.valorInicial)
+      confirmation.dialog = false;
+              confirmation.confirm = false
+              this.$router.push({
+                name: "Caixa Aberto",
+                params: { caixaId: 1 }
+              });
       storeControleCaixa(this.user_id, "dia")
         .then(res => {
           this.controleCaixa = res.data.cd_ControleCaixa;
@@ -91,6 +102,8 @@ export default {
           })
             .then(res => {
               this.caixa = res.data;
+              confirmation.dialog = false;
+              confirmation.confirm = false
               this.$router.push({
                 name: "Caixa Aberto",
                 params: { caixaId: res.data.cd_Caixa }
@@ -101,14 +114,8 @@ export default {
         .catch(err => this.errors.push(err.response));
     },
     confirm() {
-      bus.$emit('toggle', true);
+      confirmation.dialog = true;
     }
   },
-  created() {
-    bus.$on("runConfirmation", data => {
-      this.confirmation = data;
-    });
-    console.log(this.user_id)
-  }
 };
 </script>

--- a/src/views/Caixa.vue
+++ b/src/views/Caixa.vue
@@ -101,10 +101,10 @@ export default {
                 params: { caixaId: res.data.cd_Caixa }
               });
             })
-            .catch(err => this.errors.push(err.response));
+            .catch(err => this.errors.push(err.response))
         })
         .catch(err => this.errors.push(err.response))
-        .then(() => { dialogConclude() });
+        .finally(() => { dialogConclude() });
     },
     confirm() {
       openDialog();

--- a/src/views/Caixa.vue
+++ b/src/views/Caixa.vue
@@ -45,7 +45,7 @@
 
 <script>
 import Confirmation from "@/components/Confirmation";
-import { confirmation } from '../store.js';
+import { confirmation, dialogConclude, openDialog } from '../store.js';
 import { storeCaixa, storeControleCaixa, turnNumber } from "@/services/caixa";
 import { VMoney } from "v-money";
 
@@ -53,14 +53,13 @@ export default {
   name: "Caixa",
   components: { Confirmation },
   computed: {
-    dialog() {
+    dialogConfirmation() {
       return confirmation.confirm;
     }
   },
   data() {
     return {
       valorInicial: "",
-      confirmation: null,
       errors: [],
       alert: this.$route.params.alert,
       money: {
@@ -75,7 +74,7 @@ export default {
   },
 
   watch: {
-    dialog(value) {
+    dialogConfirmation(value) {
       if (value === true) {
         this.abrirCaixa();
       }
@@ -87,12 +86,6 @@ export default {
   methods: {
     abrirCaixa() {
       console.log(this.valorInicial)
-      confirmation.dialog = false;
-              confirmation.confirm = false
-              this.$router.push({
-                name: "Caixa Aberto",
-                params: { caixaId: 1 }
-              });
       storeControleCaixa(this.user_id, "dia")
         .then(res => {
           this.controleCaixa = res.data.cd_ControleCaixa;
@@ -102,8 +95,7 @@ export default {
           })
             .then(res => {
               this.caixa = res.data;
-              confirmation.dialog = false;
-              confirmation.confirm = false
+              dialogConclude();
               this.$router.push({
                 name: "Caixa Aberto",
                 params: { caixaId: res.data.cd_Caixa }
@@ -111,10 +103,11 @@ export default {
             })
             .catch(err => this.errors.push(err.response));
         })
-        .catch(err => this.errors.push(err.response));
+        .catch(err => this.errors.push(err.response))
+        .then(() => { dialogConclude() });
     },
     confirm() {
-      confirmation.dialog = true;
+      openDialog();
     }
   },
 };

--- a/src/views/CaixaAberto.vue
+++ b/src/views/CaixaAberto.vue
@@ -156,12 +156,6 @@ export default {
         .catch((err) => this.error.push(err.response));
     },
     prepararFechamento() {
-      this.salvarDados();
-    },
-    confirm() {
-      openDialog();
-    },
-    salvarDados() {
       this.items.forEach((element) => {
         if (element.categoria === "Entrada") {
           storeEntradas({
@@ -199,6 +193,9 @@ export default {
         name: "Fechamento",
         params: { caixaId: this.$route.params.caixaId },
       });
+    },
+    confirm() {
+      openDialog();
     },
   },
 

--- a/src/views/CaixaAberto.vue
+++ b/src/views/CaixaAberto.vue
@@ -67,7 +67,7 @@
 </template>
 <script>
 import Confirmation from "@/components/Confirmation";
-import { bus } from "@/plugins/bus.js";
+import { confirmation, dialogConclude, openDialog } from '../store.js';
 import { showCaixa, turnNumber } from "@/services/caixa";
 import { getTipoDespesas, storeDespesas } from "@/services/despesa";
 import { storeSangrias } from "@/services/sangria";
@@ -77,9 +77,13 @@ import { VMoney } from "v-money";
 export default {
   name: "CaixaAberto",
   components: { Confirmation },
+  computed: {
+    dialogConfirmation() {
+      return confirmation.confirm;
+    },
+  },
   data: () => ({
     caixa: {},
-    confirmation: null,
     id: 0,
     entrada: "",
     tipoDespesas: [],
@@ -97,7 +101,7 @@ export default {
   }),
 
   watch: {
-    confirmation(value) {
+    dialogConfirmation(value) {
       if (value === true) {
         this.prepararFechamento();
       }
@@ -142,13 +146,11 @@ export default {
       this.id -= 1;
     },
     fetchDespesaTipo() {
-      // GET "Lista todos os tipos de despesa"
       getTipoDespesas()
         .then((res) => (this.tipoDespesas = res.data))
         .catch((err) => this.error.push(err.response));
     },
     fetchCaixa() {
-      // GET 'Exibe o caixa pelo seu id'
       showCaixa(this.$route.params.caixaId)
         .then((res) => (this.caixa = res.data))
         .catch((err) => this.error.push(err.response));
@@ -157,7 +159,7 @@ export default {
       this.salvarDados();
     },
     confirm() {
-      bus.$emit("toggle", true);
+      openDialog();
     },
     salvarDados() {
       this.items.forEach((element) => {
@@ -191,6 +193,8 @@ export default {
             .catch((err) => this.error.push(err.response));
         }
       });
+      dialogConclude();
+      // [TODO] tirar esse router push daqui. Mesmo dando erro, vai mudar a rota!!
       this.$router.push({
         name: "Fechamento",
         params: { caixaId: this.$route.params.caixaId },
@@ -203,10 +207,5 @@ export default {
     this.fetchDespesaTipo();
   },
 
-  created() {
-    bus.$on("runConfirmation", (data) => {
-      this.confirmation = data;
-    });
-  },
 };
 </script>


### PR DESCRIPTION
Atualmente no vue 2.6 não é boa prática utilizar o `event bus` como gerenciamento de estado, pois veio algo nativo para cuidar disso, como o [Observable API](https://vuejs.org/v2/api/#Vue-observable). Tinha a opção de utilizar o Composition API também, mas é algo que entrou somento no vue 3 e teria que instalar uma `lib` para utilizá-lo, por isso não foi escolhido.